### PR TITLE
enable github actions to build binaries

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,35 @@
+name: build cross platform
+on: 
+  push:
+  pull_request:
+jobs:
+  xgo:
+    name: xgo
+    strategy:
+      matrix:
+        go_version:
+          - 1.13.x
+        os:
+          - windows
+          - linux
+          - darwin
+        arch:
+          - amd64
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v1
+    - name: Golang CGO cross compiler
+      uses: crazy-max/ghaction-xgo@v0.4.0
+      with:
+        go_version: ${{ matrix.go_version }}
+        dest: build
+        targets: ${{ matrix.os }}/${{ matrix.arch }}
+        v: false
+        x: false
+        ldflags: -s -w
+    - name: upload artifacts
+      uses: actions/upload-artifact@master
+      with:
+        name: binary ${{ matrix.go_version }} ${{ matrix.os }} ${{ matrix.arch }}
+        path: build/github.com/fleaz


### PR DESCRIPTION
This PR uses [GitHub Actions](https://github.com/features/actions) and [xgo](https://github.com/crazy-max/ghaction-xgo) to build binaries for linux, mac/darwin and windows (currently only `amd64`, feel free to add `386` if any dev still uses that). Binaries are then downloadable as [artifact](https://github.com/embix/feierabend/commit/201377ddc960989ceb8a0bb521b7a49dcf1a984a/checks?check_suite_id=266012033) within the [next 30/90 days](https://help.github.com/en/articles/persisting-workflow-data-using-artifacts#about-workflow-artifacts).

Adding binaries to releases/tags is not covered.

For GitHub Actions to work you either [need beta access to GitHub Actions](https://help.github.com/en/articles/about-github-actions#requesting-to-join-the-limited-public-beta-for-github-actions) or wait until that feature becomes publicly available.

If you don't like it, I'm Okay with that too 😎
BTW: thanks for that neat tool.
